### PR TITLE
add sudo to goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,7 +36,7 @@ builds:
       - netgo
     hooks:
       post:
-        - go run ./agent/fc-image/. {{.Path}} 
+        - sudo go run ./agent/fc-image/. {{.Path}} 
         - ls -lah
 
 archives:


### PR DESCRIPTION
Goreleaser needs sudo so that it can mount 